### PR TITLE
New composite action: Version Check

### DIFF
--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -24,12 +24,6 @@ runs:
         echo "$result" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
-    - name: DEBUG - Show outputs
-      shell: bash
-      run: |
-        echo "Status: ${{ steps.check.outputs.status }}"
-        echo "Comment: ${{ steps.check.outputs.comment }}"
-
     - name: Find existing comment
       id: find-comment
       uses: peter-evans/find-comment@v3

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -8,9 +8,10 @@ runs:
       id: check
       shell: bash
       run: |
+        set +e # Allow the script to exit non-zero and continue the workflow
         result=$("${{ github.action_path }}/../../scripts/check-versions.sh" "${{ github.event.repository.default_branch }}")
         exit_code=$?
-
+        
         if [ $exit_code -eq 0 ]; then
           echo "status=pass" >> $GITHUB_OUTPUT
         else
@@ -19,7 +20,6 @@ runs:
           echo "$result" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         fi
-
     - name: Comment on PR
       if: steps.check.outputs.status == 'fail'
       uses: thollander/actions-comment-pull-request@v3

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -20,22 +20,53 @@ runs:
           echo "$result" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         fi
-    - name: Comment on PR
-      if: steps.check.outputs.status == 'fail'
-      uses: thollander/actions-comment-pull-request@v3
-      with:
-        message: ${{ steps.check.outputs.comment }}
-        comment_tag: version-check
 
-    - name: Delete comment on success
-      if: steps.check.outputs.status == 'pass'
-      uses: thollander/actions-comment-pull-request@v3
+    - name: Find existing comment
+      if: steps.format-check.outcome == 'failure' && github.event_name == 'pull_request'
+      id: find-comment
+      uses: peter-evans/find-comment@v3
       with:
-        message: ''
-        comment_tag: version-check
-        mode: delete
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: '<!-- version-check-comment -->'
 
-    - name: Fail if checks failed
-      if: steps.check.outputs.status == 'fail'
+    - name: Create or update PR comment
+      if: steps.format-check.outcome == 'failure' && github.event_name == 'pull_request'
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        token: ${{ github.token }}
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        edit-mode: replace
+        body: ${{ steps.check.outputs.comment }}
+
+    - name: Exit with error if formatting needed
+      if: steps.format-check.outcome == 'failure'
       shell: bash
-      run: exit 1
+      run: |
+        echo "Version check failed. Please update `package.json` versions."
+        exit 1
+
+
+
+
+
+    # - name: Comment on PR
+    #   if: steps.check.outputs.status == 'fail'
+    #   uses: thollander/actions-comment-pull-request@v3
+    #   with:
+    #     message: ${{ steps.check.outputs.comment }}
+    #     comment_tag: version-check
+
+    # - name: Delete comment on success
+    #   if: steps.check.outputs.status == 'pass'
+    #   uses: thollander/actions-comment-pull-request@v3
+    #   with:
+    #     message: ''
+    #     comment_tag: version-check
+    #     mode: delete
+
+    # - name: Fail if checks failed
+    #   if: steps.check.outputs.status == 'fail'
+    #   shell: bash
+    #   run: exit 1

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -16,13 +16,16 @@ runs:
           echo "status=pass" >> $GITHUB_OUTPUT
         else
           echo "status=failure" >> $GITHUB_OUTPUT
-          echo "comment<<EOF" >> $GITHUB_OUTPUT
-          echo "$result" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
         fi
 
+        ## Write text for a PR comment, using the result of the version check script
+        echo "comment<<EOF" >> $GITHUB_OUTPUT
+        echo "<!-- version-check-comment -->" >> $GITHUB_OUTPUT
+        echo "$result" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
     - name: Find existing comment
-      if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
+      # if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       id: find-comment
       uses: peter-evans/find-comment@v3
       with:
@@ -30,11 +33,21 @@ runs:
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- version-check-comment -->'
 
+    # - name: Create or update PR comment on success
+    #   # if: steps.check.outputs.status == 'success' && github.event_name == 'pull_request'
+    #   uses: peter-evans/create-or-update-comment@v4
+    #   with:
+    #     comment-id: ${{ steps.find-comment.outputs.comment-id }}
+    #     issue-number: ${{ github.event.pull_request.number }}
+    #     edit-mode: replace
+    #     body: |
+    #       <!-- version-check-comment -->
+    #       ## ✅ Version checks passed
+
     - name: Create or update PR comment
-      if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
+      # if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       with:
-        token: ${{ github.token }}
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         edit-mode: replace

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -24,6 +24,12 @@ runs:
         echo "$result" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
 
+    - name: DEBUG - Show outputs
+      shell: bash
+      run: |
+        echo "Status: ${{ steps.check.outputs.status }}"
+        echo "Comment: ${{ steps.check.outputs.comment }}"
+
     - name: Find existing comment
       # if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       id: find-comment
@@ -53,11 +59,11 @@ runs:
         edit-mode: replace
         body: ${{ steps.check.outputs.comment }}
 
-    - name: Exit with error if formatting needed
+    - name: Exit with error if version-increment needed
       if: steps.check.outputs.status == 'failure'
       shell: bash
       run: |
-        echo "Version check failed. Please update `package.json` versions."
+        echo "Version check failed. Please update package.json versions."
         exit 1
 
 

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -17,6 +17,9 @@ runs:
         else
           echo "status=failure" >> $GITHUB_OUTPUT
         fi
+        echo "-------------------"
+        echo $result
+        echo "-------------------"
 
         ## Write text for a PR comment, using the result of the version check script
         echo "comment<<EOF" >> $GITHUB_OUTPUT

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -1,5 +1,5 @@
 name: Package Version Check
-description: Validates package.json versions are consistent and advanced
+description: Validates package.json versions are consistent and incremented
 
 runs:
   using: composite
@@ -31,7 +31,7 @@ runs:
       if: steps.check.outputs.status == 'pass'
       uses: thollander/actions-comment-pull-request@v3
       with:
-        message: ""
+        message: ''
         comment_tag: version-check
         mode: delete
 

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -22,7 +22,7 @@ runs:
         fi
 
     - name: Find existing comment
-      if: steps.format-check.outcome == 'failure' && github.event_name == 'pull_request'
+      if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       id: find-comment
       uses: peter-evans/find-comment@v3
       with:
@@ -31,7 +31,7 @@ runs:
         body-includes: '<!-- version-check-comment -->'
 
     - name: Create or update PR comment
-      if: steps.format-check.outcome == 'failure' && github.event_name == 'pull_request'
+      if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ github.token }}
@@ -41,7 +41,7 @@ runs:
         body: ${{ steps.check.outputs.comment }}
 
     - name: Exit with error if formatting needed
-      if: steps.format-check.outcome == 'failure'
+      if: steps.check.outputs.status == 'failure'
       shell: bash
       run: |
         echo "Version check failed. Please update `package.json` versions."

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -17,9 +17,6 @@ runs:
         else
           echo "status=failure" >> $GITHUB_OUTPUT
         fi
-        echo "-------------------"
-        echo $result
-        echo "-------------------"
 
         ## Write text for a PR comment, using the result of the version check script
         echo "comment<<EOF" >> $GITHUB_OUTPUT
@@ -34,7 +31,6 @@ runs:
         echo "Comment: ${{ steps.check.outputs.comment }}"
 
     - name: Find existing comment
-      # if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       id: find-comment
       uses: peter-evans/find-comment@v3
       with:
@@ -42,19 +38,7 @@ runs:
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- version-check-comment -->'
 
-    # - name: Create or update PR comment on success
-    #   # if: steps.check.outputs.status == 'success' && github.event_name == 'pull_request'
-    #   uses: peter-evans/create-or-update-comment@v4
-    #   with:
-    #     comment-id: ${{ steps.find-comment.outputs.comment-id }}
-    #     issue-number: ${{ github.event.pull_request.number }}
-    #     edit-mode: replace
-    #     body: |
-    #       <!-- version-check-comment -->
-    #       ## ✅ Version checks passed
-
     - name: Create or update PR comment
-      # if: steps.check.outputs.status == 'failure' && github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -68,27 +52,3 @@ runs:
       run: |
         echo "Version check failed. Please update package.json versions."
         exit 1
-
-
-
-
-
-    # - name: Comment on PR
-    #   if: steps.check.outputs.status == 'fail'
-    #   uses: thollander/actions-comment-pull-request@v3
-    #   with:
-    #     message: ${{ steps.check.outputs.comment }}
-    #     comment_tag: version-check
-
-    # - name: Delete comment on success
-    #   if: steps.check.outputs.status == 'pass'
-    #   uses: thollander/actions-comment-pull-request@v3
-    #   with:
-    #     message: ''
-    #     comment_tag: version-check
-    #     mode: delete
-
-    # - name: Fail if checks failed
-    #   if: steps.check.outputs.status == 'fail'
-    #   shell: bash
-    #   run: exit 1

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -1,0 +1,41 @@
+name: Package Version Check
+description: Validates package.json versions are consistent and advanced
+
+runs:
+  using: composite
+  steps:
+    - name: Check versions
+      id: check
+      shell: bash
+      run: |
+        result=$("${{ github.action_path }}/../../scripts/check-versions.sh" "${{ github.event.repository.default_branch }}")
+        exit_code=$?
+
+        if [ $exit_code -eq 0 ]; then
+          echo "status=pass" >> $GITHUB_OUTPUT
+        else
+          echo "status=fail" >> $GITHUB_OUTPUT
+          echo "comment<<EOF" >> $GITHUB_OUTPUT
+          echo "$result" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Comment on PR
+      if: steps.check.outputs.status == 'fail'
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        message: ${{ steps.check.outputs.comment }}
+        comment_tag: version-check
+
+    - name: Delete comment on success
+      if: steps.check.outputs.status == 'pass'
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        message: ""
+        comment_tag: version-check
+        mode: delete
+
+    - name: Fail if checks failed
+      if: steps.check.outputs.status == 'fail'
+      shell: bash
+      run: exit 1

--- a/.github/actions/version-check/action.yaml
+++ b/.github/actions/version-check/action.yaml
@@ -15,7 +15,7 @@ runs:
         if [ $exit_code -eq 0 ]; then
           echo "status=pass" >> $GITHUB_OUTPUT
         else
-          echo "status=fail" >> $GITHUB_OUTPUT
+          echo "status=failure" >> $GITHUB_OUTPUT
           echo "comment<<EOF" >> $GITHUB_OUTPUT
           echo "$result" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -71,7 +71,7 @@ echo "Current version: $curr" >&2
 echo "Default version: $def" >&2
 
 i=0
-for i in major minor patch; do
+for part in major minor patch; do
   [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "## ✅ Version Checks Passed" && exit 0
   [ "${curr[$i]}" -lt "${def[$i]}" ] && break
   ((i++))

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -68,13 +68,13 @@ IFS='.' read -r -a curr <<< "$current_base"
 IFS='.' read -r -a def <<< "$default_base"
 
 i=0
-for part in major minor patch; do
-  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "✅ Version checks passed" && exit 0
+for i in major minor patch; do
+  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "## ✅ Version Checks Passed" && exit 0
   [ "${curr[$i]}" -lt "${def[$i]}" ] && break
   ((i++))
 done
 
 # Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
-[ "$current" != "$default_version" ] && exit 0
+[ "$current" != "$default_version" ] && echo "## ✅ Version Checks Passed" && exit 0
 
 version_not_incremented

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# check-versions.sh - Package version consistency and advancement checker
+# Validates that all package.json files have consistent versions and that
+# the version has advanced beyond the default branch.
+#
+# Usage: ./check-versions.sh [default-branch]
+#
+set -e
+
+DEFAULT_BRANCH=${1:-main}
+
+# Find package.json files (excluding node_modules)
+files=$(find . -path "*/node_modules" -prune -o -name "package.json" \( -path "./package.json" -o -path "./modules/*/package.json" \) -print)
+
+[ -z "$files" ] && echo "No package.json files found" && exit 0
+
+# Extract versions
+versions=$(echo "$files" | while read -r file; do
+  version=$(jq -r '.version' "$file")
+  echo "$file: $version" >&2
+  echo "$file|$version"
+done)
+
+# Check consistency
+unique=$(echo "$versions" | cut -d'|' -f2 | sort -u | wc -l)
+
+if [ "$unique" -gt 1 ]; then
+  echo "## ❌ Inconsistent Package Versions"
+  echo
+  echo "$versions" | while IFS='|' read -r file ver; do
+    echo "- \`${file#./}\`: **$ver**"
+    echo "::error file=${file#./}::Inconsistent version: $ver" >&2
+  done
+  echo
+  echo "All package.json files must have the same version."
+  exit 1
+fi
+
+# Check version advancement
+current=$(echo "$versions" | cut -d'|' -f2 | head -1)
+default_version=$(git show "origin/$DEFAULT_BRANCH:package.json" 2>/dev/null | jq -r '.version' || echo "")
+
+[ -z "$default_version" ] && echo "No package.json on default branch" >&2 && exit 0
+
+echo "Comparing $current against $default_version" >&2
+
+# If versions are exactly the same, fail
+[ "$current" = "$default_version" ] && {
+  echo "## ❌ Version Not Advanced"
+  echo
+  echo "Current version: **$current**"
+  echo "Default branch version: **$default_version**"
+  echo
+  echo "The version must be advanced beyond the default branch."
+  echo "::error file=package.json::Version not advanced: $current (was $default_version)" >&2
+  exit 1
+}
+
+# Strip any suffix (e.g., -rc.N) for semantic comparison
+current_base="${current%%-*}"
+default_base="${default_version%%-*}"
+
+# Compare semantic versions (major.minor.patch)
+IFS='.' read -r -a curr <<< "$current_base"
+IFS='.' read -r -a def <<< "$default_base"
+
+i=0
+for part in major minor patch; do
+  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "✅ Version checks passed" && exit 0
+  [ "${curr[$i]}" -lt "${def[$i]}" ] && break
+  ((i++))
+done
+
+# Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
+[ "$current" != "$default_version" ] && exit 0
+
+# Version not advanced
+echo "## ❌ Version Not Advanced"
+echo
+echo "Current version: **$current**"
+echo "Default branch version: **$default_version**"
+echo
+echo "The version must be advanced beyond the default branch."
+echo "::error file=package.json::Version not advanced: $current (was $default_version)" >&2
+exit 1

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -67,6 +67,9 @@ default_base="${default_version%%-*}"
 IFS='.' read -r -a curr <<< "$current_base"
 IFS='.' read -r -a def <<< "$default_base"
 
+echo "Current version: $curr" >&2
+echo "Default version: $def" >&2
+
 i=0
 for i in major minor patch; do
   [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "## ✅ Version Checks Passed" && exit 0

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -5,7 +5,7 @@
 #
 # Usage: ./check-versions.sh [default-branch]
 #
-set -e
+set -ex
 
 DEFAULT_BRANCH=${1:-main}
 

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -5,12 +5,12 @@
 #
 # Usage: ./check-versions.sh [default-branch]
 #
-set -ex
+set -e
 
 DEFAULT_BRANCH=${1:-main}
 
 # Find package.json files (excluding node_modules)
-files=$(find . -path "*/node_modules" -prune -o -name "package.json" \( -path "./package.json" -o -path "./modules/*/package.json" \) -print)
+files=$(find . -path "*/node_modules/*" -prune -o -name "package.json" -print)
 
 [ -z "$files" ] && echo "No package.json files found" && exit 0
 

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -44,7 +44,7 @@ default_version=$(git show "origin/$DEFAULT_BRANCH:package.json" 2>/dev/null | j
 
 echo "Comparing $current against $default_version" >&2
 
-version_warning<<EOF
+version_warning=$(cat <<EOF
   ## ⚠️ Version Not Incremented
   
   Current version: **$current**

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -44,22 +44,20 @@ default_version=$(git show "origin/$DEFAULT_BRANCH:package.json" 2>/dev/null | j
 
 echo "Comparing $current against $default_version" >&2
 
-version_warning=$(cat <<EOF
-  ## ⚠️ Version Not Incremented
-  
-  Current version: **$current**
-  Default branch version: **$default_version**
-  
-  The version must be incremented beyond the default branch.
-  ::error file=package.json::Version not incremented: $current (was $default_version)"
-EOF
-)
-
-# If versions are exactly the same, fail
-[ "$current" = "$default_version" ] && {
-  echo $version_warning >&2
+# Function to output message for use in the PR comment
+version_not_incremented() {
+  echo "## ⚠️ Version Not Incremented"
+  echo
+  echo "Current version: **$current**"
+  echo "Default branch version: **$default_version**"
+  echo
+  echo "The version must be incremented beyond the default branch."
+  echo "::error file=package.json::Version not incremented: $current (was $default_version)" >&2
   exit 1
 }
+
+# If versions are exactly the same, fail
+[ "$current" = "$default_version" ] && version_not_incremented
 
 # Strip any suffix (e.g., -rc.N) for semantic comparison
 current_base="${current%%-*}"
@@ -79,6 +77,4 @@ done
 # Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
 [ "$current" != "$default_version" ] && exit 0
 
-# Version has not advanced
-echo $version_warning >&2
-exit 1
+version_not_incremented

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -69,12 +69,12 @@ IFS='.' read -r -a def <<< "$default_base"
 
 i=0
 for i in major minor patch; do
-  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "\#\# ✅ Version Checks Passed" && exit 0
+  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "## ✅ Version Checks Passed" && exit 0
   [ "${curr[$i]}" -lt "${def[$i]}" ] && break
   ((i++))
 done
 
 # Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
-[ "$current" != "$default_version" ] && echo "\#\# ✅ Version Checks Passed" && exit 0
+[ "$current" != "$default_version" ] && echo "## ✅ Version Checks Passed" && exit 0
 
 version_not_incremented

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -53,6 +53,7 @@ version_warning=$(cat <<EOF
   The version must be incremented beyond the default branch.
   ::error file=package.json::Version not incremented: $current (was $default_version)"
 EOF
+)
 
 # If versions are exactly the same, fail
 [ "$current" = "$default_version" ] && {

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -44,15 +44,19 @@ default_version=$(git show "origin/$DEFAULT_BRANCH:package.json" 2>/dev/null | j
 
 echo "Comparing $current against $default_version" >&2
 
+version_warning<<EOF
+  ## ⚠️ Version Not Incremented
+  
+  Current version: **$current**
+  Default branch version: **$default_version**
+  
+  The version must be incremented beyond the default branch.
+  ::error file=package.json::Version not incremented: $current (was $default_version)"
+EOF
+
 # If versions are exactly the same, fail
 [ "$current" = "$default_version" ] && {
-  echo "## ⚠️ Version Not Incremented"
-  echo
-  echo "Current version: **$current**"
-  echo "Default branch version: **$default_version**"
-  echo
-  echo "The version must be incremented beyond the default branch."
-  echo "::error file=package.json::Version not incremented: $current (was $default_version)" >&2
+  echo $version_warning >&2
   exit 1
 }
 
@@ -74,12 +78,6 @@ done
 # Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
 [ "$current" != "$default_version" ] && exit 0
 
-# Version not advanced
-echo "## ❌ Version Not Advanced"
-echo
-echo "Current version: **$current**"
-echo "Default branch version: **$default_version**"
-echo
-echo "The version must be advanced beyond the default branch."
-echo "::error file=package.json::Version not advanced: $current (was $default_version)" >&2
+# Version has not advanced
+echo $version_warning >&2
 exit 1

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -69,12 +69,12 @@ IFS='.' read -r -a def <<< "$default_base"
 
 i=0
 for i in major minor patch; do
-  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "## ✅ Version Checks Passed" && exit 0
+  [ "${curr[$i]}" -gt "${def[$i]}" ] && echo "\#\# ✅ Version Checks Passed" && exit 0
   [ "${curr[$i]}" -lt "${def[$i]}" ] && break
   ((i++))
 done
 
 # Base versions are equal but full versions differ (e.g., suffix changed) - that's ok
-[ "$current" != "$default_version" ] && echo "## ✅ Version Checks Passed" && exit 0
+[ "$current" != "$default_version" ] && echo "\#\# ✅ Version Checks Passed" && exit 0
 
 version_not_incremented

--- a/.github/scripts/check-versions.sh
+++ b/.github/scripts/check-versions.sh
@@ -46,13 +46,13 @@ echo "Comparing $current against $default_version" >&2
 
 # If versions are exactly the same, fail
 [ "$current" = "$default_version" ] && {
-  echo "## ❌ Version Not Advanced"
+  echo "## ⚠️ Version Not Incremented"
   echo
   echo "Current version: **$current**"
   echo "Default branch version: **$default_version**"
   echo
-  echo "The version must be advanced beyond the default branch."
-  echo "::error file=package.json::Version not advanced: $current (was $default_version)" >&2
+  echo "The version must be incremented beyond the default branch."
+  echo "::error file=package.json::Version not incremented: $current (was $default_version)" >&2
   exit 1
 }
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The infrastructure-tooling repository contains standardized CI/CD components spe
 
 - **`markdown-link-checker/`** - Validates links in markdown files (README, CHANGELOG, etc.)
 - **`formatter-check/`** - Checks formatting using language-appropriate tooling (prettier, black, gofmt), posting a comment on PRs when not passing.
+- **`version-check/`** - Validates package.json versions are consistent across workspace and incremented from default branch
 
 ### Workflows (`.github/workflows/`)
 
@@ -97,6 +98,17 @@ Contract size validation script:
 - Fails for contracts >24KB (exceeds Ethereum limit)
 - Color-coded terminal output for easy identification
 
+#### `check-versions.sh`
+
+Package version validation script:
+
+- Finds all package.json files in workspace (excluding node_modules)
+- Validates version consistency across multiple package.json files
+- Ensures version has been advanced beyond the default branch
+- Supports semantic version comparison (major.minor.patch)
+- Handles version suffixes (e.g., -rc.N) appropriately
+- Posts GitHub Actions annotations for validation failures
+
 ## 🔧 Usage
 
 ### As a Callable Workflow
@@ -137,6 +149,9 @@ steps:
       package-manager: "yarn" # or npm
 
   - uses: Forte-Service-Company-Ltd/infrastructure-tooling/.github/actions/typescript-test@main
+  
+  # For version validation (for projects having package.json) 
+  - uses: Forte-Service-Company-Ltd/infrastructure-tooling/.github/actions/version-check@main
 ```
 
 ## 🛠 Supported Technologies
@@ -173,6 +188,7 @@ steps:
 - **Link Validation**: Prevents broken documentation links
 - **Dependency Management**: Automated installation and updates
 - **Format Validation**: Ensures code formatting conforms to accepted conventions
+- **Version Consistency**: Validates package.json versions are consistent and properly incremented
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
Testing (as a local script):

When passing:
```
/Users/arthur/code/infrastructure-tooling/.github/scripts/check-versions.sh
./package.json: 0.1.2-rc3
Comparing 0.1.2-rc3 against 0.1.1
✅ Version checks passed
```

When not passing:
```
/Users/arthur/code/infrastructure-tooling/.github/scripts/check-versions.sh
./package.json: 0.7.1
./modules/server/package.json: 0.7.1
./modules/sdk/package.json: 0.7.1
./modules/client/package.json: 0.7.2
## ❌ Inconsistent Package Versions

- `package.json`: **0.7.1**
::error file=package.json::Inconsistent version: 0.7.1
- `modules/server/package.json`: **0.7.1**
::error file=modules/server/package.json::Inconsistent version: 0.7.1
- `modules/sdk/package.json`: **0.7.1**
::error file=modules/sdk/package.json::Inconsistent version: 0.7.1
- `modules/client/package.json`: **0.7.2**
::error file=modules/client/package.json::Inconsistent version: 0.7.2

All package.json files must have the same version.
```

Testing in Forte-Staking-UI:

<img width="1179" height="386" alt="image" src="https://github.com/user-attachments/assets/a6c483ac-a9ff-4300-b45b-f07b7d01d592" />

When inconsistently updated (among modules of FRE-UI): 
<img width="1379" height="483" alt="image" src="https://github.com/user-attachments/assets/5637b0bc-5b06-451e-9f80-04dc68557ee9" />

Also tested with `package.json` incremented, causing the check to pass, as shown: 
<img width="1198" height="273" alt="image" src="https://github.com/user-attachments/assets/c4afe8af-c222-41f6-83e6-5a14a89b9502" />